### PR TITLE
Fix behavior when cache is empty

### DIFF
--- a/Manual/README.md
+++ b/Manual/README.md
@@ -702,8 +702,10 @@ As such, we can change the function which interacts with the REST API to leverag
     
       let cache = await caches.open('pwabuilder-offline');
       let cacheResult = await cache.match(url);
-      let json = await cacheResult.json();
-      $('#messages').html(json.count + ' New messages!');
+      if (cacheResult) {
+          let json = await cacheResult.json();
+          $('#messages').html(json.count + ' New messages!');
+      }
     
       let httpResult = await fetch(url);
       let jsonResult = await httpResult.json();


### PR DESCRIPTION
I had found an issue at `Task 3 - Cache specific requests (optional task)`.
The code had not checked the result from cache.
In this case, below error is occurred when cache is empty:
![image](https://user-images.githubusercontent.com/79868/51305845-4c03d880-1a7f-11e9-81ef-46f780d2ab0c.png)

I've added if statements to check when cache wouldn't find.