### PR TITLE
add Kestrel settings for fixing port number issue

### DIFF
--- a/Lab/Exercise3/01-Start/Contoso.PushServer/appsettings.json
+++ b/Lab/Exercise3/01-Start/Contoso.PushServer/appsettings.json
@@ -5,5 +5,15 @@
     }
   },
   "AllowedHosts": "*",
-  "DatabasePath": "channels.db"
+  "DatabasePath": "channels.db",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:1983"
+      },
+      "HttpsDefaultCert": {
+        "Url": "https://localhost:1984"
+      }
+    }
+  }
 }

--- a/Lab/Exercise3/02-End/Contoso.PushServer/appsettings.json
+++ b/Lab/Exercise3/02-End/Contoso.PushServer/appsettings.json
@@ -5,5 +5,15 @@
     }
   },
   "AllowedHosts": "*",
-  "DatabasePath": "channels.db"
+  "DatabasePath": "channels.db",
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://localhost:1983"
+      },
+      "HttpsDefaultCert": {
+        "Url": "https://localhost:1984"
+      }
+    }
+  }
 }


### PR DESCRIPTION
In Task 4, running Contoso Backend website using `dotnet run` command, the website use port number 5000, then conflict Contoso.WebAPI.
I added Kestrel section to appsettings.json for to change to use port number 1983, written by following document.

https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-2.2#endpoint-configuration

#### Before
```
PS C:\Users\kaota\Documents\Repos\ForWork\Windows-AppConsult-PWALab\Lab\Exercise3\01-Start\Contoso.PushServer> dotnet run
Hosting environment: Production
Content root path: C:\Users\kaota\Documents\Repos\ForWork\Windows-AppConsult-PWALab\Lab\Exercise3\01-Start\Contoso.PushServer
Now listening on: http://localhost:5000
Now listening on: https://localhost:5001
Application started. Press Ctrl+C to shut down.
```

#### After
````
PS C:\Users\kaota\Documents\Repos\ForWork\Windows-AppConsult-PWALab\Lab\Exercise3\01-Start\Contoso.PushServer> dotnet run
Hosting environment: Production
Content root path: C:\Users\kaota\Documents\Repos\ForWork\Windows-AppConsult-PWALab\Lab\Exercise3\01-Start\Contoso.PushServer
Now listening on: http://localhost:1983
Now listening on: https://localhost:1984
````